### PR TITLE
Update AdapterModule to use bindToAdapter method invocation

### DIFF
--- a/app/src/main/java/com/cuttingedge/PokeApp/Backpack/BackpackActivity.java
+++ b/app/src/main/java/com/cuttingedge/PokeApp/Backpack/BackpackActivity.java
@@ -66,8 +66,8 @@ public class BackpackActivity extends BaseActivity {
                 .setSwipeRight(Color.GREEN, ResourcesCompat.getDrawable(getResources(), R.drawable.ic_cloud_upload_white_24dp, null))
                 .build();
 
-        new PokemonBackPackModule(this, adapter);
-        new HeaderModule(adapter);
+        new PokemonBackPackModule(this).bindToAdapter(adapter);
+        new HeaderModule().bindToAdapter(adapter);
     }
 
 

--- a/app/src/main/java/com/cuttingedge/PokeApp/Backpack/HeaderModule.java
+++ b/app/src/main/java/com/cuttingedge/PokeApp/Backpack/HeaderModule.java
@@ -7,7 +7,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.cuttingedge.PokeApp.R;
-import com.cuttingedge.adapter2recycler.Adapter.ModularAdapter;
 import com.cuttingedge.adapter2recycler.Modules.AdapterModule;
 
 /**
@@ -17,10 +16,6 @@ import com.cuttingedge.adapter2recycler.Modules.AdapterModule;
  */
 
 class HeaderModule extends AdapterModule<HeaderModule.HeaderViewHolder, Header> {
-
-    HeaderModule(ModularAdapter adapter) {
-        super(adapter);
-    }
 
     @Override
     public HeaderViewHolder onCreateViewHolder(ViewGroup parent) {

--- a/app/src/main/java/com/cuttingedge/PokeApp/Backpack/PokemonBackPackModule.java
+++ b/app/src/main/java/com/cuttingedge/PokeApp/Backpack/PokemonBackPackModule.java
@@ -11,7 +11,6 @@ import com.cuttingedge.PokeApp.Pokedex;
 import com.cuttingedge.PokeApp.Pokemon;
 import com.cuttingedge.PokeApp.PokemonModule;
 import com.cuttingedge.PokeApp.R;
-import com.cuttingedge.adapter2recycler.Adapter.ModularAdapter;
 import com.cuttingedge.adapter2recycler.Modules.ItemClickPlugin;
 import com.cuttingedge.adapter2recycler.Modules.ItemLongClickPlugin;
 
@@ -32,8 +31,7 @@ class PokemonBackPackModule extends PokemonModule
      * AdapterModule methods *
      *************************/
 
-    PokemonBackPackModule(Context context, ModularAdapter adapter) {
-        super(adapter);
+    PokemonBackPackModule(Context context) {
         this.context = context;
     }
 

--- a/app/src/main/java/com/cuttingedge/PokeApp/BillsPC/BillsPCActivity.java
+++ b/app/src/main/java/com/cuttingedge/PokeApp/BillsPC/BillsPCActivity.java
@@ -53,7 +53,7 @@ public class BillsPCActivity extends BaseActivity {
                 .setSwipeRight(Color.GREEN, ResourcesCompat.getDrawable(getResources(), R.drawable.ic_cloud_download_white_24dp, null))
                 .build();
 
-        new PokemonBillsPCModule(adapter);
+        new PokemonBillsPCModule().bindToAdapter(adapter);
     }
 
 

--- a/app/src/main/java/com/cuttingedge/PokeApp/BillsPC/PokemonBillsPCModule.java
+++ b/app/src/main/java/com/cuttingedge/PokeApp/BillsPC/PokemonBillsPCModule.java
@@ -9,7 +9,6 @@ import com.cuttingedge.PokeApp.Pokedex;
 import com.cuttingedge.PokeApp.Pokemon;
 import com.cuttingedge.PokeApp.PokemonModule;
 import com.cuttingedge.PokeApp.R;
-import com.cuttingedge.adapter2recycler.Adapter.ModularAdapter;
 
 import java.util.List;
 
@@ -23,10 +22,6 @@ class PokemonBillsPCModule extends PokemonModule{
     /*************************
      * AdapterModule methods *
      *************************/
-
-    PokemonBillsPCModule(ModularAdapter adapter) {
-        super(adapter);
-    }
 
     @Override
     public PokemonViewHolder onCreateViewHolder(ViewGroup parent) {

--- a/app/src/main/java/com/cuttingedge/PokeApp/PokemonModule.java
+++ b/app/src/main/java/com/cuttingedge/PokeApp/PokemonModule.java
@@ -8,7 +8,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.cuttingedge.adapter2recycler.Adapter.ModularAdapter;
 import com.cuttingedge.adapter2recycler.Modules.AdapterModule;
 import com.cuttingedge.adapter2recycler.Modules.DragAndDropPlugin;
 import com.cuttingedge.adapter2recycler.Modules.SwipePlugin;
@@ -26,10 +25,6 @@ public abstract class PokemonModule
     /*************************
      * AdapterModule methods *
      *************************/
-
-    public PokemonModule(ModularAdapter adapter) {
-        super(adapter);
-    }
 
     @Override
     public PokemonViewHolder onCreateViewHolder(ViewGroup parent) {

--- a/library/src/main/java/com/cuttingedge/adapter2recycler/Modules/AdapterModule.java
+++ b/library/src/main/java/com/cuttingedge/adapter2recycler/Modules/AdapterModule.java
@@ -16,13 +16,12 @@ import java.lang.reflect.ParameterizedType;
 @SuppressWarnings("unused")
 public abstract class AdapterModule<VH extends ViewHolder, I extends ModularItem> {
 
-
     /**
-     * Construct module and add itself to manager via adapter.
+     * Binds the module to the manager via adapter.
      *
-     * @param adapter ModularAdapter for which this module is meant to be used
+     * @param adapter ModularAdapter for which this module is meant to be used.
      */
-    public AdapterModule(ModularAdapter adapter) {
+    public void bindToAdapter(ModularAdapter adapter) {
         adapter.addAdapterModule(this);
     }
 


### PR DESCRIPTION
This pull request resolves the potential issue of leaking `this` in the AdapterModule constructor by binding the module to the manager via adapter after the module has been fully constructed. Adding this method also prevents us from having to add the module to the manager at the activity level, which causes unchecked method invocation warnings.